### PR TITLE
Bug fix: When registering a new user, the message "Each field must be…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,3 +3,7 @@
 ## 1.0.0
 
 - Initial Release
+
+#### 1.0.1
+
+- Bug fix: When registering a new user, the message "Each field must be filled" was displayed, although all fields were set.

--- a/crackpipe/UserControls/SettingsComponents/RegisterUserControl.xaml.cs
+++ b/crackpipe/UserControls/SettingsComponents/RegisterUserControl.xaml.cs
@@ -73,7 +73,7 @@ namespace crackpipe.UserControls.SettingsComponents
             var properties = SettingsViewModel.Instance.RegistrationUser.GetType().GetProperties();
             foreach (var property in properties)
             {
-                if (property.Name != "DeletedAt" && property.Name != "Progresses" && property.Name != "ProfilePicture")
+                if (property.Name != "DeletedAt" && property.Name != "Progresses" && property.Name != "ProfilePicture" && property.Name != "Role")
                 {
                     if (property.GetValue(SettingsViewModel.Instance.RegistrationUser) == null || property.GetValue(SettingsViewModel.Instance.RegistrationUser).ToString() == string.Empty)
                     {

--- a/crackpipe/ViewModels/SettingsViewModel.cs
+++ b/crackpipe/ViewModels/SettingsViewModel.cs
@@ -147,7 +147,7 @@ namespace crackpipe.ViewModels
         {
             get
             {
-                return "1.0.0";
+                return "1.0.1";
             }
         }
 


### PR DESCRIPTION
… filled" was displayed, although all fields were set.